### PR TITLE
Add logic allows get permission from another google account

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,121 +2,134 @@
 var googleAuth = (function () {
 
   function installClient() {
-    var apiUrl = 'https://apis.google.com/js/api.js'
-    return new Promise((resolve) => {
-      var script = document.createElement('script')
-      script.src = apiUrl
-      script.onreadystatechange = script.onload = function () {
-        if (!script.readyState || /loaded|complete/.test(script.readyState)) {
-          setTimeout(function () {
-            resolve()
-          }, 500)
-        }
-      }
-      document.getElementsByTagName('head')[0].appendChild(script)
-    })
+      var apiUrl = 'https://apis.google.com/js/api.js'
+      return new Promise((resolve) => {
+          var script = document.createElement('script')
+          script.src = apiUrl
+          script.onreadystatechange = script.onload = function () {
+              if (!script.readyState || /loaded|complete/.test(script.readyState)) {
+                  setTimeout(function () {
+                      resolve()
+                  }, 500)
+              }
+          }
+          document.getElementsByTagName('head')[0].appendChild(script)
+      })
   }
 
   function initClient(config) {
-    return new Promise((resolve, reject) => {
-      window.gapi.load('auth2', () => {
-        window.gapi.auth2.init(config)
-          .then(() => {
-            resolve(window.gapi)
-          }).catch((error) => {
-            reject(error)
+      return new Promise((resolve, reject) => {
+          window.gapi.load('auth2', () => {
+              window.gapi.auth2.init(config)
+                  .then(() => {
+                      resolve(window.gapi)
+                  }).catch((error) => {
+                      reject(error)
+                  })
           })
       })
-    })
 
   }
 
   function Auth() {
-    if (!(this instanceof Auth))
-      return new Auth()
-    this.GoogleAuth = null /* window.gapi.auth2.getAuthInstance() */
-    this.isAuthorized = false
-    this.isInit = false
-    this.prompt = null
-    this.isLoaded = function () {
-      /* eslint-disable */
+      if (!(this instanceof Auth)) 
+        return new Auth()
+      this.GoogleAuth = null /* window.gapi.auth2.getAuthInstance() */
+      this.isAuthorized = false
+      this.isInit = false
+      this.prompt = null
+      this.isLoaded = function () {
+          /* eslint-disable */
       console.warn('isLoaded() will be deprecated. You can use "this.$gAuth.isInit"')
-      return !!this.GoogleAuth
-    };
+          return !!this.GoogleAuth
+      };
 
-    this.load = (config, prompt) => {
-      installClient()
-        .then(() => {
-          return initClient(config)
-        })
-        .then((gapi) => {
-          this.GoogleAuth = gapi.auth2.getAuthInstance()
-          this.isInit = true
-          this.prompt = prompt
-          this.isAuthorized = this.GoogleAuth.isSignedIn.get()
-        }).catch((error) => {
-          console.error(error)
-        })
-    };
+      this.load = (config, prompt) => {
+          installClient()
+              .then(() => {
+                  return initClient(config)
+              })
+              .then((gapi) => {
+                  this.GoogleAuth = gapi.auth2.getAuthInstance()
+                  this.isInit = true
+                  this.prompt = prompt
+                  this.isAuthorized = this.GoogleAuth.isSignedIn.get()
+              }).catch((error) => {
+                  console.error(error)
+              })
+      };
 
-    this.signIn = (successCallback, errorCallback) => {
-      return new Promise((resolve, reject) => {
-        if (!this.GoogleAuth) {
-          if (typeof errorCallback === 'function') errorCallback(false)
-          reject(false)
-          return
-        }
-        this.GoogleAuth.signIn()
-          .then(googleUser => {
-            if (typeof successCallback === 'function') successCallback(googleUser)
-            this.isAuthorized = this.GoogleAuth.isSignedIn.get()
-            resolve(googleUser)
+      this.signIn = (successCallback, errorCallback) => {
+          return new Promise((resolve, reject) => {
+              if (!this.GoogleAuth) {
+                  if (typeof errorCallback === 'function') errorCallback(false)
+                  reject(false)
+                  return
+              }
+              this.GoogleAuth.signIn()
+                  .then(googleUser => {
+                      if (typeof successCallback === 'function') successCallback(googleUser)
+                      this.isAuthorized = this.GoogleAuth.isSignedIn.get()
+                      resolve(googleUser)
+                  })
+                  .catch(error => {
+                      if (typeof errorCallback === 'function') errorCallback(error)
+                      reject(error)
+                  })
           })
-          .catch(error => {
-            if (typeof errorCallback === 'function') errorCallback(error)
-            reject(error)
-          })
-      })
-    };
+      };
 
-    this.getAuthCode = (successCallback, errorCallback) => {
-      return new Promise((resolve, reject) => {
-        if (!this.GoogleAuth) {
-          if (typeof errorCallback === 'function') errorCallback(false)
-          reject(false)
-          return
-        }
-        this.GoogleAuth.grantOfflineAccess({ prompt: this.prompt })
-          .then(function (resp) {
-            if (typeof successCallback === 'function') successCallback(resp.code)
-            resolve(resp.code)
+      this.getAuthCodeWithOption = (options, successCallback, errorCallback) => {
+          return new Promise((resolve, reject) => {
+              if (!this.GoogleAuth) {
+                  if (typeof errorCallback === 'function') errorCallback(false)
+                  reject(false)
+                  return;
+              }
+              let option = { prompt: this.prompt }
+              if (options && typeof options === 'object') {
+                  if (options.prompt) {
+                      option.prompt = options.prompt
+                  }
+                  if (options.scope) {
+                      option.scope = options.scope
+                  }
+              }
+              this.GoogleAuth.grantOfflineAccess(option)
+                  .then(function (resp) {
+                      if (typeof successCallback === 'function') successCallback(resp.code);
+                      resolve(resp.code)
+                  })
+                  .catch(function (error) {
+                      if (typeof errorCallback === 'function') errorCallback(error)
+                      reject(error)
+                  })
           })
-          .catch(function (error) {
-            if (typeof errorCallback === 'function') errorCallback(error)
-            reject(error)
-          })
-      })
-    };
+      };
 
-    this.signOut = (successCallback, errorCallback) => {
-      return new Promise((resolve, reject) => {
-        if (!this.GoogleAuth) {
-          if (typeof errorCallback === 'function') errorCallback(false)
-          reject(false)
-          return
-        }
-        this.GoogleAuth.signOut()
-          .then(() => {
-            if (typeof successCallback === 'function') successCallback()
-            this.isAuthorized = false
-            resolve(true)
+      this.getAuthCode = (successCallback, errorCallback) => {
+          return this.getAuthCodeWithOption(null, successCallback, errorCallback)
+      };
+
+      this.signOut = (successCallback, errorCallback) => {
+          return new Promise((resolve, reject) => {
+              if (!this.GoogleAuth) {
+                  if (typeof errorCallback === 'function') errorCallback(false)
+                  reject(false)
+                  return
+              }
+              this.GoogleAuth.signOut()
+                  .then(() => {
+                      if (typeof successCallback === 'function') successCallback()
+                      this.isAuthorized = false
+                      resolve(true)
+                  })
+                  .catch(error => {
+                      if (typeof errorCallback === 'function') errorCallback(error)
+                      reject(error)
+                  })
           })
-          .catch(error => {
-            if (typeof errorCallback === 'function') errorCallback(error)
-            reject(error)
-          })
-      })
-    };
+      };
   }
 
   return new Auth()
@@ -132,24 +145,24 @@ function installGoogleAuthPlugin(Vue, options) {
   let GoogleAuthDefaultConfig = { scope: 'profile email', discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/drive/v3/rest'] }
   let prompt = 'select_account'
   if (typeof options === 'object') {
-    GoogleAuthConfig = Object.assign(GoogleAuthDefaultConfig, options)
-    if (options.scope) GoogleAuthConfig.scope = options.scope
-    if (options.prompt) prompt = options.prompt
-    if (!options.clientId) {
-      console.warn('clientId is required')
-    }
+      GoogleAuthConfig = Object.assign(GoogleAuthDefaultConfig, options)
+      if (options.scope) GoogleAuthConfig.scope = options.scope
+      if (options.prompt) prompt = options.prompt
+      if (!options.clientId) {
+          console.warn('clientId is required')
+      }
   } else {
-    console.warn('invalid option type. Object type accepted only')
+      console.warn('invalid option type. Object type accepted only')
   }
 
   //Install Vue plugin
   Vue.gAuth = googleAuth
   Object.defineProperties(Vue.prototype, {
-    $gAuth: {
-      get: function () {
-        return Vue.gAuth
+      $gAuth: {
+          get: function () {
+              return Vue.gAuth
+          }
       }
-    }
   })
   Vue.gAuth.load(GoogleAuthConfig, prompt)
 }

--- a/index.ts
+++ b/index.ts
@@ -87,7 +87,7 @@ const googleAuth = ((): any => {
       });
     };
 
-    this.getAuthCode = (successCallback: any, errorCallback: any) => {
+    this.getAuthCodeWithOption = (options, successCallback, errorCallback) => {
       return new Promise((resolve, reject) => {
         if (!this.GoogleAuth) {
           if (typeof errorCallback === 'function') {
@@ -96,7 +96,16 @@ const googleAuth = ((): any => {
           reject(false);
           return;
         }
-        this.GoogleAuth.grantOfflineAccess({ prompt: this.prompt })
+        let option = { prompt: this.prompt }
+        if (options && typeof options === 'object') {
+            if (options.prompt) {
+                option.prompt = options.prompt
+            }
+            if (options.scope) {
+                option["scope"] = options.scope
+            }
+        }
+        this.GoogleAuth.grantOfflineAccess(option)
           .then((resp: any) => {
             if (typeof successCallback === 'function') {
               successCallback(resp.code);
@@ -110,6 +119,10 @@ const googleAuth = ((): any => {
             reject(error);
           });
       });
+  };
+
+    this.getAuthCode = (successCallback: any, errorCallback: any) => {
+      return this.getAuthCodeWithOption(null, successCallback, errorCallback)
     };
 
     this.signOut = (successCallback: any, errorCallback: any) => {


### PR DESCRIPTION
- Support for requesting other account permissions which are different from previously logged in accounts
- Use the syntax here 
```
    const options = {
            scope: "https://www.googleapis.com/auth/content https://www.googleapis.com/auth/adwords",
            prompt: "consent",
        };
    this.$gAuth
        .getAuthCodeWithOption(options)
        .then((authCode) => {
            // do something
        })
        .catch((error) => {
            //on fail do something
        });
```